### PR TITLE
タスク10.1「Cursor Settings UI連携」の実装

### DIFF
--- a/.kiro/specs/cursorcli-mcp-server/tasks.md
+++ b/.kiro/specs/cursorcli-mcp-server/tasks.md
@@ -257,7 +257,7 @@ CursorCLI-MCPServerは、既存のCursorCLIをModel Context Protocol（MCP）サ
   - _Requirements: 5.6_
 
 - [ ] 10. Cursor IDE統合機能の実装
-- [ ] 10.1 Cursor Settings UI連携
+- [x] 10.1 Cursor Settings UI連携
   - mcpServers設定フォーマットへの対応
   - 環境変数管理機能（env フィールド）
   - サーバー有効/無効切り替えのサポート

--- a/src/cursor-integration/index.ts
+++ b/src/cursor-integration/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Cursor IDE Integration Module Exports
+ */
+
+export { CursorIntegrationManager } from './manager.js';
+export type { CursorIntegrationOptions, CursorConfigChangeCallback } from './manager.js';
+export {
+  McpServerConfigSchema,
+  McpServersSchema,
+  CursorSettingsSchema,
+  DEFAULT_CURSOR_SETTINGS,
+} from './schema.js';
+export type { McpServerConfig, CursorSettings } from './schema.js';

--- a/src/cursor-integration/manager.ts
+++ b/src/cursor-integration/manager.ts
@@ -1,0 +1,235 @@
+/**
+ * Cursor IDE統合マネージャー
+ *
+ * Cursor IDEのmcpServers設定フォーマットに対応し、
+ * 環境変数管理、サーバー有効/無効切り替え、設定同期を実現します。
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import chokidar from 'chokidar';
+import { CursorSettingsSchema, type CursorSettings, DEFAULT_CURSOR_SETTINGS } from './schema.js';
+
+/**
+ * Cursor統合マネージャーのオプション
+ */
+export interface CursorIntegrationOptions {
+  cursorConfigPath?: string;
+}
+
+/**
+ * 設定変更コールバック
+ */
+export type CursorConfigChangeCallback = () => void;
+
+/**
+ * Cursor IDE統合マネージャー
+ */
+export class CursorIntegrationManager {
+  private cursorConfigPath: string;
+  private cursorSettings: CursorSettings | null = null;
+  private watcher: chokidar.FSWatcher | null = null;
+  private changeCallbacks: CursorConfigChangeCallback[] = [];
+  private reloadTimeout: NodeJS.Timeout | null = null;
+
+  constructor(options: CursorIntegrationOptions = {}) {
+    // Cursor設定ファイルのパスを決定
+    this.cursorConfigPath =
+      options.cursorConfigPath ||
+      path.join(process.env.HOME || process.env.USERPROFILE || '', '.cursor', 'settings.json');
+  }
+
+  /**
+   * Cursor設定を読み込み
+   */
+  async loadCursorConfig(): Promise<CursorSettings> {
+    try {
+      // 設定ファイルの存在確認
+      await fs.access(this.cursorConfigPath);
+
+      // ファイルの読み込み
+      const fileContent = await fs.readFile(this.cursorConfigPath, 'utf-8');
+      const parsedSettings = JSON.parse(fileContent);
+
+      // バリデーション
+      this.cursorSettings = CursorSettingsSchema.parse(parsedSettings);
+      return this.cursorSettings;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        // 設定ファイルが存在しない場合、デフォルト設定を返す
+        this.cursorSettings = { ...DEFAULT_CURSOR_SETTINGS };
+        return this.cursorSettings;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * 環境変数を解決
+   *
+   * ${VAR_NAME} 形式の参照を実際の環境変数の値に置き換えます。
+   */
+  async resolveEnvironmentVariables(serverName: string): Promise<Record<string, string>> {
+    if (!this.cursorSettings) {
+      await this.loadCursorConfig();
+    }
+
+    const serverConfig = this.cursorSettings?.mcpServers?.[serverName];
+    if (!serverConfig || !serverConfig.env) {
+      return {};
+    }
+
+    const resolvedEnv: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(serverConfig.env)) {
+      // ${VAR_NAME} 形式の参照を検出して解決
+      const envVarMatch = value.match(/^\$\{([^}]+)\}$/);
+      if (envVarMatch) {
+        const envVarName = envVarMatch[1];
+        resolvedEnv[key] = process.env[envVarName] || '';
+      } else {
+        resolvedEnv[key] = value;
+      }
+    }
+
+    return resolvedEnv;
+  }
+
+  /**
+   * サーバーが有効かチェック
+   */
+  async isServerEnabled(serverName: string): Promise<boolean> {
+    if (!this.cursorSettings) {
+      await this.loadCursorConfig();
+    }
+
+    const serverConfig = this.cursorSettings?.mcpServers?.[serverName];
+    if (!serverConfig) {
+      return false;
+    }
+
+    return serverConfig.disabled !== true;
+  }
+
+  /**
+   * サーバーを有効化
+   */
+  async enableServer(serverName: string): Promise<void> {
+    if (!this.cursorSettings) {
+      await this.loadCursorConfig();
+    }
+
+    if (!this.cursorSettings || !this.cursorSettings.mcpServers[serverName]) {
+      throw new Error(`Server "${serverName}" not found in Cursor settings`);
+    }
+
+    // disabled フラグを false に設定
+    this.cursorSettings.mcpServers[serverName].disabled = false;
+
+    // 設定ファイルに書き込み
+    await this.saveCursorConfig();
+  }
+
+  /**
+   * サーバーを無効化
+   */
+  async disableServer(serverName: string): Promise<void> {
+    if (!this.cursorSettings) {
+      await this.loadCursorConfig();
+    }
+
+    if (!this.cursorSettings || !this.cursorSettings.mcpServers[serverName]) {
+      throw new Error(`Server "${serverName}" not found in Cursor settings`);
+    }
+
+    // disabled フラグを true に設定
+    this.cursorSettings.mcpServers[serverName].disabled = true;
+
+    // 設定ファイルに書き込み
+    await this.saveCursorConfig();
+  }
+
+  /**
+   * Cursor設定をファイルに保存
+   */
+  private async saveCursorConfig(): Promise<void> {
+    if (!this.cursorSettings) {
+      throw new Error('No Cursor settings to save');
+    }
+
+    const configContent = JSON.stringify(this.cursorSettings, null, 2);
+    await fs.writeFile(this.cursorConfigPath, configContent, 'utf-8');
+  }
+
+  /**
+   * Cursor設定の変更を監視
+   */
+  watchCursorConfig(callback: CursorConfigChangeCallback): void {
+    // コールバックを登録
+    this.changeCallbacks.push(callback);
+
+    // 既に監視中の場合は何もしない
+    if (this.watcher) {
+      return;
+    }
+
+    // chokidarでCursor設定ファイルを監視
+    this.watcher = chokidar.watch(this.cursorConfigPath, {
+      persistent: true,
+      ignoreInitial: true,
+      awaitWriteFinish: {
+        stabilityThreshold: 100,
+        pollInterval: 50,
+      },
+    });
+
+    this.watcher.on('change', () => {
+      // Debounce: 連続したイベントをマージ
+      if (this.reloadTimeout) {
+        clearTimeout(this.reloadTimeout);
+        this.reloadTimeout = null;
+      }
+
+      // 200msの非アクティブ後に設定を再読み込み
+      this.reloadTimeout = setTimeout(async () => {
+        try {
+          // 設定を再読み込み
+          await this.loadCursorConfig();
+
+          // すべてのコールバックを実行
+          this.changeCallbacks.forEach((cb) => cb());
+        } catch (error) {
+          // エラーが発生した場合はデフォルト設定にフォールバック
+          this.cursorSettings = { ...DEFAULT_CURSOR_SETTINGS };
+          this.changeCallbacks.forEach((cb) => cb());
+        } finally {
+          this.reloadTimeout = null;
+        }
+      }, 200);
+    });
+  }
+
+  /**
+   * Cursor設定の監視を停止
+   */
+  async stopWatching(): Promise<void> {
+    // 保留中のリロードタイムアウトをクリア
+    if (this.reloadTimeout) {
+      clearTimeout(this.reloadTimeout);
+      this.reloadTimeout = null;
+    }
+
+    if (this.watcher) {
+      await this.watcher.close();
+      this.watcher = null;
+    }
+    this.changeCallbacks = [];
+  }
+
+  /**
+   * 現在のCursor設定を取得
+   */
+  getCursorSettings(): CursorSettings | null {
+    return this.cursorSettings;
+  }
+}

--- a/src/cursor-integration/schema.ts
+++ b/src/cursor-integration/schema.ts
@@ -1,0 +1,51 @@
+/**
+ * Cursor IDE統合のスキーマ定義
+ *
+ * Cursor IDEのmcpServers設定フォーマットに対応するための型定義とスキーマ
+ */
+
+import { z } from 'zod';
+
+/**
+ * MCPサーバー設定スキーマ
+ */
+export const McpServerConfigSchema = z.object({
+  command: z.string().min(1).describe('起動コマンド（例: node, python）'),
+  args: z.array(z.string()).default([]).describe('コマンドライン引数'),
+  env: z
+    .record(z.string())
+    .optional()
+    .describe('環境変数（${VAR_NAME}形式でプロセス環境変数を参照可能）'),
+  disabled: z.boolean().optional().default(false).describe('サーバーの有効/無効状態'),
+  cwd: z.string().optional().describe('作業ディレクトリ'),
+});
+
+/**
+ * MCPサーバー設定型
+ */
+export type McpServerConfig = z.infer<typeof McpServerConfigSchema>;
+
+/**
+ * Cursor設定のmcpServersセクションスキーマ
+ */
+export const McpServersSchema = z.record(McpServerConfigSchema);
+
+/**
+ * Cursor設定全体のスキーマ
+ */
+export const CursorSettingsSchema = z.object({
+  mcpServers: McpServersSchema.optional().default({}),
+  // 他のCursor設定フィールドは必要に応じて追加
+});
+
+/**
+ * Cursor設定型
+ */
+export type CursorSettings = z.infer<typeof CursorSettingsSchema>;
+
+/**
+ * デフォルトのCursor設定
+ */
+export const DEFAULT_CURSOR_SETTINGS: CursorSettings = {
+  mcpServers: {},
+};

--- a/tests/unit/cursor-integration.test.ts
+++ b/tests/unit/cursor-integration.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Cursor IDE統合機能のテスト
+ *
+ * Requirements: 9.1, 9.6
+ * - mcpServers設定フォーマットへの対応
+ * - 環境変数管理機能（env フィールド）
+ * - サーバー有効/無効切り替えのサポート
+ * - 設定同期機能の実装
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { CursorIntegrationManager } from '../../src/cursor-integration/manager.js';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+describe('CursorIntegrationManager', () => {
+  let tempDir: string;
+  let manager: CursorIntegrationManager;
+
+  beforeEach(async () => {
+    // テスト用の一時ディレクトリを作成
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cursor-integration-test-'));
+    manager = new CursorIntegrationManager({
+      cursorConfigPath: path.join(tempDir, 'cursor-settings.json'),
+    });
+  });
+
+  afterEach(async () => {
+    // 一時ディレクトリをクリーンアップ
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('mcpServers設定フォーマット対応', () => {
+    it('Cursor設定からmcpServers設定を読み込める', async () => {
+      // Arrange: Cursor設定ファイルを作成
+      const cursorSettings = {
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            command: 'node',
+            args: ['/path/to/server.js'],
+            disabled: false,
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(cursorSettings, null, 2)
+      );
+
+      // Act: 設定を読み込み
+      const config = await manager.loadCursorConfig();
+
+      // Assert: mcpServers設定が取得できる
+      expect(config.mcpServers).toBeDefined();
+      expect(config.mcpServers['cursorcli-mcp-server']).toBeDefined();
+      expect(config.mcpServers['cursorcli-mcp-server'].command).toBe('node');
+    });
+
+    it('mcpServers設定が存在しない場合、デフォルト設定を返す', async () => {
+      // Arrange: 空のCursor設定ファイルを作成
+      await fs.writeFile(path.join(tempDir, 'cursor-settings.json'), JSON.stringify({}, null, 2));
+
+      // Act: 設定を読み込み
+      const config = await manager.loadCursorConfig();
+
+      // Assert: デフォルトのmcpServers設定が返される
+      expect(config.mcpServers).toBeDefined();
+      expect(Object.keys(config.mcpServers)).toHaveLength(0);
+    });
+  });
+
+  describe('環境変数管理機能', () => {
+    it('env フィールドから環境変数を読み込める', async () => {
+      // Arrange: 環境変数を含むCursor設定を作成
+      const cursorSettings = {
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            command: 'node',
+            args: ['/path/to/server.js'],
+            env: {
+              MCP_LOG_LEVEL: 'debug',
+              API_KEY: '${API_KEY}',
+            },
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(cursorSettings, null, 2)
+      );
+
+      // Act: 環境変数を解決
+      const resolvedEnv = await manager.resolveEnvironmentVariables('cursorcli-mcp-server');
+
+      // Assert: 環境変数が解決される
+      expect(resolvedEnv.MCP_LOG_LEVEL).toBe('debug');
+      expect(resolvedEnv.API_KEY).toBeDefined();
+    });
+
+    it('環境変数の参照形式を正しく解決する', async () => {
+      // Arrange: テスト用の環境変数を設定
+      process.env.TEST_API_KEY = 'test-secret-key';
+      const cursorSettings = {
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            command: 'node',
+            args: ['/path/to/server.js'],
+            env: {
+              API_KEY: '${TEST_API_KEY}',
+            },
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(cursorSettings, null, 2)
+      );
+
+      // Act: 環境変数を解決
+      const resolvedEnv = await manager.resolveEnvironmentVariables('cursorcli-mcp-server');
+
+      // Assert: 環境変数が正しく解決される
+      expect(resolvedEnv.API_KEY).toBe('test-secret-key');
+
+      // Cleanup
+      delete process.env.TEST_API_KEY;
+    });
+  });
+
+  describe('サーバー有効/無効切り替え', () => {
+    it('サーバーが無効の場合、disabled: trueを検出する', async () => {
+      // Arrange: 無効化されたサーバー設定
+      const cursorSettings = {
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            command: 'node',
+            args: ['/path/to/server.js'],
+            disabled: true,
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(cursorSettings, null, 2)
+      );
+
+      // Act: サーバーが有効かチェック
+      const isEnabled = await manager.isServerEnabled('cursorcli-mcp-server');
+
+      // Assert: サーバーは無効
+      expect(isEnabled).toBe(false);
+    });
+
+    it('サーバーが有効の場合、disabled: falseまたは未設定を検出する', async () => {
+      // Arrange: 有効なサーバー設定
+      const cursorSettings = {
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            command: 'node',
+            args: ['/path/to/server.js'],
+            disabled: false,
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(cursorSettings, null, 2)
+      );
+
+      // Act: サーバーが有効かチェック
+      const isEnabled = await manager.isServerEnabled('cursorcli-mcp-server');
+
+      // Assert: サーバーは有効
+      expect(isEnabled).toBe(true);
+    });
+
+    it('サーバーを有効化できる', async () => {
+      // Arrange: 無効なサーバー設定
+      const cursorSettings = {
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            command: 'node',
+            args: ['/path/to/server.js'],
+            disabled: true,
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(cursorSettings, null, 2)
+      );
+
+      // Act: サーバーを有効化
+      await manager.enableServer('cursorcli-mcp-server');
+
+      // Assert: 設定ファイルが更新される
+      const updatedSettings = JSON.parse(
+        await fs.readFile(path.join(tempDir, 'cursor-settings.json'), 'utf-8')
+      );
+      expect(updatedSettings.mcpServers['cursorcli-mcp-server'].disabled).toBe(false);
+    });
+
+    it('サーバーを無効化できる', async () => {
+      // Arrange: 有効なサーバー設定
+      const cursorSettings = {
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            command: 'node',
+            args: ['/path/to/server.js'],
+            disabled: false,
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(cursorSettings, null, 2)
+      );
+
+      // Act: サーバーを無効化
+      await manager.disableServer('cursorcli-mcp-server');
+
+      // Assert: 設定ファイルが更新される
+      const updatedSettings = JSON.parse(
+        await fs.readFile(path.join(tempDir, 'cursor-settings.json'), 'utf-8')
+      );
+      expect(updatedSettings.mcpServers['cursorcli-mcp-server'].disabled).toBe(true);
+    });
+  });
+
+  describe('設定同期機能', () => {
+    it('Cursor設定が変更されたら、変更を検知する', async () => {
+      // Arrange: 初期設定
+      const initialSettings = {
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            command: 'node',
+            args: ['/path/to/server.js'],
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(initialSettings, null, 2)
+      );
+
+      let changeDetected = false;
+      const callback = () => {
+        changeDetected = true;
+      };
+
+      // Act: 設定変更を監視
+      manager.watchCursorConfig(callback);
+
+      // 設定を更新
+      const updatedSettings = {
+        ...initialSettings,
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            ...initialSettings.mcpServers['cursorcli-mcp-server'],
+            disabled: true,
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(updatedSettings, null, 2)
+      );
+
+      // Wait for file watcher to detect change
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Assert: 変更が検知される
+      expect(changeDetected).toBe(true);
+
+      // Cleanup
+      await manager.stopWatching();
+    });
+
+    it('Cursor設定の変更を自動的にサーバー設定に反映する', async () => {
+      // Arrange: 初期設定
+      const initialSettings = {
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            command: 'node',
+            args: ['/path/to/server.js'],
+            env: {
+              MCP_LOG_LEVEL: 'info',
+            },
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(initialSettings, null, 2)
+      );
+
+      let syncedEnv: Record<string, string> = {};
+      const callback = async () => {
+        syncedEnv = await manager.resolveEnvironmentVariables('cursorcli-mcp-server');
+      };
+
+      // Act: 設定同期を開始
+      manager.watchCursorConfig(callback);
+
+      // 設定を更新
+      const updatedSettings = {
+        ...initialSettings,
+        mcpServers: {
+          'cursorcli-mcp-server': {
+            ...initialSettings.mcpServers['cursorcli-mcp-server'],
+            env: {
+              MCP_LOG_LEVEL: 'debug',
+            },
+          },
+        },
+      };
+      await fs.writeFile(
+        path.join(tempDir, 'cursor-settings.json'),
+        JSON.stringify(updatedSettings, null, 2)
+      );
+
+      // Wait for sync
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Assert: 環境変数が同期される
+      expect(syncedEnv.MCP_LOG_LEVEL).toBe('debug');
+
+      // Cleanup
+      await manager.stopWatching();
+    });
+  });
+});


### PR DESCRIPTION
  実装内容

  1. Cursor IDE設定スキーマの定義 ✅

  - McpServerConfigSchema: MCP サーバー設定のZodスキーマ
  - CursorSettingsSchema: Cursor IDE設定全体のスキーマ
  - 環境変数参照（${VAR_NAME}形式）に対応

  2. 環境変数管理機能 ✅

  - resolveEnvironmentVariables(): ${VAR_NAME}形式の参照を実際の環境変数に解決
  - プロセス環境変数からの安全な読み込み

  3. サーバー有効/無効切り替え ✅

  - isServerEnabled(): サーバーの有効状態を確認
  - enableServer(): サーバーを有効化
  - disableServer(): サーバーを無効化
  - Cursor設定ファイルへの変更を自動保存

  4. 設定同期機能 ✅

  - watchCursorConfig(): Cursor設定ファイルの変更を監視
  - ファイル変更時のコールバック実行（200msデバウンス）
  - エラー時のデフォルト設定へのフォールバック

  テスト結果

  ✅ 全10個のテストケースが成功
  - mcpServers設定フォーマット対応: 2件
  - 環境変数管理機能: 2件
  - サーバー有効/無効切り替え: 4件
  - 設定同期機能: 2件

  作成ファイル

  - src/cursor-integration/schema.ts - Cursor設定スキーマ定義
  - src/cursor-integration/manager.ts - Cursor統合マネージャー実装
  - src/cursor-integration/index.ts - モジュールエクスポート
  - tests/unit/cursor-integration.test.ts - 単体テスト
